### PR TITLE
Changed method for trilateration 

### DIFF
--- a/Include/DSP_constants.h
+++ b/Include/DSP_constants.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include "arm_math.h"
 #include "arm_const_structs.h" 
+#include "parameters.h"
 
 /**
  * @brief Duplicating code is terrible code-practice! These constants somehow 

--- a/Include/hydrophones.h
+++ b/Include/hydrophones.h
@@ -11,7 +11,8 @@
  * @note It is thought that the hydrophones are
  * placed in a form of a triangle. Therefore, we
  * have one on front starboard, one on front port
- * and one on the back in the middle
+ * and one on the stern in the middle. Could be changed
+ * in the future
  * 
  *                    BOW
  *                      
@@ -27,6 +28,9 @@
  *           '''''''''HYD'''''''''
  * 
  *                   STERN
+ * 
+ * @note The position of the hydrophones are relative
+ * to the center of the AUV
  */
 #ifndef ACOUSTICS_HYDROPHONES_H
 #define ACOUSTICS_HYDROPHONES_H
@@ -42,13 +46,28 @@
  * is used. See the datasheet at 
  * https://www.benthowave.com/products/Specs/BII-7014FGPGDatasheet.pdf
  * for more information
+ * 
+ * @note Position of the hydrophones are relative to the center of the 
+ * AUV
  */
 #ifndef HYDROPHONE_DETAILS
 #define HYDROPHONE_DETAILS
 
-  #define NUM_HYDROPHONES   3        /* Number of hydrophones used on the AUV       */
-  #define HYD_PREAMP_DB     40       /* Number of dB the signal is preamplifies     */
-  #define HYD_FFVS          -173     /* Average FFVS for 20 - 40 kHz [dB V/μPa]     */    
+  #define NUM_HYDROPHONES   3         /* Number of hydrophones used on the AUV        */
+  #define HYD_PREAMP_DB     40        /* Number of dB the signal is preamplifies      */
+  #define HYD_FFVS          -173      /* Average FFVS for 20 - 40 kHz [dB V/μPa]      */  
+
+  #define PORT_HYD_X        -1.0      /* x - position of port hydrophone      [m]     */
+  #define PORT_HYD_Y        0.0       /* y - position of port hydrophone      [m]     */
+  #define PORT_HYD_Z        0.0       /* z - position of port hydrophone      [m]     */
+
+  #define STARBOARD_HYD_X   1.0       /* x - position of starboard hydrophone [m]     */
+  #define STARBOARD_HYD_Y   0.0       /* y - position of starboard hydrophone [m]     */
+  #define STARBOARD_HYD_Z   0.0       /* z - position of starboard hydrophone [m]     */
+
+  #define STERN_HYD_X       0.0       /* x - position of stern hydrophone     [m]     */
+  #define STERN_HYD_Y       -1.0      /* y - position of stern hydrophone     [m]     */
+  #define STERN_HYD_Z       0.0       /* z - position of stern hydrophone     [m]     */
 
 #endif /* HYDROPHONE_DETAILS */
 
@@ -61,9 +80,9 @@ namespace HYDROPHONES{
  * center of the AUV. Must be updated in the future
  * when the placement of the hydrophones are known
  */
-TRILATERATION::Pos pos_hyd_port(-1, 0, 0);
-TRILATERATION::Pos pos_hyd_starboard(1, 0, 0);
-TRILATERATION::Pos pos_hyd_stern(0, -1, 0);
+TRILATERATION::Pos pos_hyd_port{PORT_HYD_X, PORT_HYD_Y, PORT_HYD_Z};
+TRILATERATION::Pos pos_hyd_starboard{STARBOARD_HYD_X, STARBOARD_HYD_Y, STARBOARD_HYD_Z};
+TRILATERATION::Pos pos_hyd_stern{STERN_HYD_X, STERN_HYD_Y, STERN_HYD_Z};
 
 
 /**
@@ -88,16 +107,6 @@ private:
     uint32_t last_lag;
 
     /**
-     * @brief The maximum value detected 
-     */
-    float32_t* p_max_val;
-
-    /**
-     * @brief The index the maximum magnitude was detected on
-     */
-    uint32_t* p_idx;
-
-    /**
      * @brief The intensity calculated for the last sample
      */
     float32_t last_intensity;
@@ -106,11 +115,6 @@ private:
     * @brief The dataset for one hydrophone 
     */
     float32_t* p_data;
-
-    /**
-     * @brief The magnitude of the dataset
-     */
-    float32_t* p_mag_data;
 
     /**
      * @brief The autocorrelated data-sequence
@@ -142,9 +146,9 @@ public:
     * 
     * The raw data is filtered using a second-order biquad DF1 
     * IIR filter to eliminate unwanted frequencies. Thereafter
-    * the frequencies magnitude and autocorrelation are found.
-    * The lag, intensity and distance are thereafter estimated 
-    * from these measurements
+    * the autocorrelation is found and used to calculate the lag, 
+    * intensity and distance are thereafter estimated 
+    * from the filtered data
     */
     void analyze_data(float32_t* p_raw_data);
 }; /* class Hydrophones */

--- a/Include/hydrophones.h
+++ b/Include/hydrophones.h
@@ -4,10 +4,6 @@
  * @brief Small library that implements the 
  * hydrophones for the AUV for Vortex NTNU
  * 
- * @note Could be improved by using the pose
- * from ROS. Should be implemented in the 
- * future
- * 
  * @note It is thought that the hydrophones are
  * placed in a form of a triangle. Therefore, we
  * have one on front starboard, one on front port

--- a/Include/hydrophones.h
+++ b/Include/hydrophones.h
@@ -37,41 +37,6 @@
 
 #include "trilateration.h"
 
-
-/**
- * @brief Defines that indicate the setup of the hardware on the AUV
- * 
- * These variables must be changed according to the hydrophones used.
- * As of 03.01.21, three hydrophones of the type Benthowave BII-7014FG 
- * is used. See the datasheet at 
- * https://www.benthowave.com/products/Specs/BII-7014FGPGDatasheet.pdf
- * for more information
- * 
- * @note Position of the hydrophones are relative to the center of the 
- * AUV
- */
-#ifndef HYDROPHONE_DETAILS
-#define HYDROPHONE_DETAILS
-
-  #define NUM_HYDROPHONES   3         /* Number of hydrophones used on the AUV        */
-  #define HYD_PREAMP_DB     40        /* Number of dB the signal is preamplifies      */
-  #define HYD_FFVS          -173      /* Average FFVS for 20 - 40 kHz [dB V/μPa]      */  
-
-  #define PORT_HYD_X        -1.0      /* x - position of port hydrophone      [m]     */
-  #define PORT_HYD_Y        0.0       /* y - position of port hydrophone      [m]     */
-  #define PORT_HYD_Z        0.0       /* z - position of port hydrophone      [m]     */
-
-  #define STARBOARD_HYD_X   1.0       /* x - position of starboard hydrophone [m]     */
-  #define STARBOARD_HYD_Y   0.0       /* y - position of starboard hydrophone [m]     */
-  #define STARBOARD_HYD_Z   0.0       /* z - position of starboard hydrophone [m]     */
-
-  #define STERN_HYD_X       0.0       /* x - position of stern hydrophone     [m]     */
-  #define STERN_HYD_Y       -1.0      /* y - position of stern hydrophone     [m]     */
-  #define STERN_HYD_Z       0.0       /* z - position of stern hydrophone     [m]     */
-
-#endif /* HYDROPHONE_DETAILS */
-
-
 namespace HYDROPHONES{
 
 /**

--- a/Include/parameters.h
+++ b/Include/parameters.h
@@ -22,24 +22,46 @@
 #ifndef HYDROPHONE_DETAILS
 #define HYDROPHONE_DETAILS
 
-  #define NUM_HYDROPHONES   3         /* Number of hydrophones used on the AUV        */
-  #define HYD_PREAMP_DB     40        /* Number of dB the signal is preamplifies      */
-  #define HYD_FFVS          -173      /* Average FFVS for 20 - 40 kHz [dB V/μPa]      */  
+  #define NUM_HYDROPHONES   3         /* Number of hydrophones used on the AUV          */
+  #define HYD_PREAMP_DB     40        /* Number of dB the signal is preamplifies        */
+  #define HYD_FFVS         -173       /* Average FFVS for 20 - 40 kHz [dB V/μPa]        */  
 
-  #define SIGNAL_GAIN       1.0f      /* Gain of signal (unknown as of 06.01)         */
+  #define SIGNAL_GAIN       1.0f      /* Gain of signal (unknown as of 06.01)           */
 
-  #define PORT_HYD_X        -1.0f     /* x - position of port hydrophone      [m]     */
-  #define PORT_HYD_Y        0.0f      /* y - position of port hydrophone      [m]     */
-  #define PORT_HYD_Z        0.0f      /* z - position of port hydrophone      [m]     */
+  #define PORT_HYD_X       -1.0f      /* x - position of port hydrophone      [m]       */
+  #define PORT_HYD_Y        0.0f      /* y - position of port hydrophone      [m]       */
+  #define PORT_HYD_Z        0.0f      /* z - position of port hydrophone      [m]       */
 
-  #define STARBOARD_HYD_X   1.0f      /* x - position of starboard hydrophone [m]     */
-  #define STARBOARD_HYD_Y   0.0f      /* y - position of starboard hydrophone [m]     */
-  #define STARBOARD_HYD_Z   0.0f      /* z - position of starboard hydrophone [m]     */
+  #define STARBOARD_HYD_X   1.0f      /* x - position of starboard hydrophone [m]       */
+  #define STARBOARD_HYD_Y   0.0f      /* y - position of starboard hydrophone [m]       */
+  #define STARBOARD_HYD_Z   0.0f      /* z - position of starboard hydrophone [m]       */
 
-  #define STERN_HYD_X       0.0f      /* x - position of stern hydrophone     [m]     */
-  #define STERN_HYD_Y       -1.0f     /* y - position of stern hydrophone     [m]     */
-  #define STERN_HYD_Z       0.0f      /* z - position of stern hydrophone     [m]     */
+  #define STERN_HYD_X       0.0f      /* x - position of stern hydrophone     [m]       */
+  #define STERN_HYD_Y      -1.0f      /* y - position of stern hydrophone     [m]       */
+  #define STERN_HYD_Z       0.0f      /* z - position of stern hydrophone     [m]       */
 
 #endif /* HYDROPHONE_DETAILS */
+
+
+/**
+ * @brief Defines that indicate the errors that we can allow and still 
+ * get an acceptable result 
+ */
+#ifndef SYSTEM_MARGINS
+#define SYSTEM_MARGINS
+
+  #define MARGIN_POS_ESTIMATE 0.5f    /* Error tolerable in estimating the position [m] */
+  #define MARGIN_POS_SEARCH   0.25f   /* How much the search will deviate in x      [m] */          
+
+  #define MARGIN_INTENSITY    20      /* Difference between the intensity-measurements  */       
+  #define MARGIN_TIME_EPSILON 0.1f    /* Determines the difference allowed between the  */
+                                      /* detected lags. With LAG_DIFF_EPSILON = 0.1 we  */
+                                      /* allow signals to arrive 1.1 * max_time and     */
+                                      /* still count. max_time is the maximum           */
+                                      /* possible time for sound to pass from one to    */
+                                      /* another hydrophone                             */
+
+
+#endif /* SYSTEM_MARGINS */
 
 #endif /* ACOUSTICS_PARAMETERS_H */

--- a/Include/parameters.h
+++ b/Include/parameters.h
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * 
+ * @brief Parameters and constants used for the system/AUV that a lot of the code
+ * must know 
+ */
+#ifndef ACOUSTICS_PARAMETERS_H
+#define ACOUSTICS_PARAMETERS_H
+
+/**
+ * @brief Defines that indicate the setup of the hardware on the AUV
+ * 
+ * These variables must be changed according to the hydrophones used.
+ * As of 03.01.21, three hydrophones of the type Benthowave BII-7014FG 
+ * is used. See the datasheet at 
+ * https://www.benthowave.com/products/Specs/BII-7014FGPGDatasheet.pdf
+ * for more information
+ * 
+ * @note Position of the hydrophones are relative to the center of the 
+ * AUV
+ */
+#ifndef HYDROPHONE_DETAILS
+#define HYDROPHONE_DETAILS
+
+  #define NUM_HYDROPHONES   3         /* Number of hydrophones used on the AUV        */
+  #define HYD_PREAMP_DB     40        /* Number of dB the signal is preamplifies      */
+  #define HYD_FFVS          -173      /* Average FFVS for 20 - 40 kHz [dB V/μPa]      */  
+
+  #define SIGNAL_GAIN       1.0f      /* Gain of signal (unknown as of 06.01)         */
+
+  #define PORT_HYD_X        -1.0f     /* x - position of port hydrophone      [m]     */
+  #define PORT_HYD_Y        0.0f      /* y - position of port hydrophone      [m]     */
+  #define PORT_HYD_Z        0.0f      /* z - position of port hydrophone      [m]     */
+
+  #define STARBOARD_HYD_X   1.0f      /* x - position of starboard hydrophone [m]     */
+  #define STARBOARD_HYD_Y   0.0f      /* y - position of starboard hydrophone [m]     */
+  #define STARBOARD_HYD_Z   0.0f      /* z - position of starboard hydrophone [m]     */
+
+  #define STERN_HYD_X       0.0f      /* x - position of stern hydrophone     [m]     */
+  #define STERN_HYD_Y       -1.0f     /* y - position of stern hydrophone     [m]     */
+  #define STERN_HYD_Z       0.0f      /* z - position of stern hydrophone     [m]     */
+
+#endif /* HYDROPHONE_DETAILS */
+
+#endif /* ACOUSTICS_PARAMETERS_H */

--- a/Include/parameters.h
+++ b/Include/parameters.h
@@ -64,4 +64,16 @@
 
 #endif /* SYSTEM_MARGINS */
 
+
+/**
+ * @brief Defines that indicate physical characteristics/constants 
+ * of the system
+ */
+#ifndef PHYSICAL_CONSTANTS
+#define PHYSICAL_CONSTANTS
+
+  #define SOUND_SPEED       1480.0f   /* Speed of sound in water [m/s]                    */
+
+#endif /* PHYSICAL_CONSTANTS */
+
 #endif /* ACOUSTICS_PARAMETERS_H */

--- a/Include/trilateration.h
+++ b/Include/trilateration.h
@@ -303,6 +303,22 @@ uint8_t valid_intensity_check(
  */
 void transform_data(float32_t* p_data);
 
+
+/**
+ * @brief Function to trilaterate the position of the acoustic pinger based
+ * on the time of arrival. The function calculates the TDOA, and uses it to 
+ * calculate the position.
+ * 
+ * Based on the MATLAB-code propused in the article
+ * https://www.researchgate.net/publication/265336167_A_Novel_Trilateration_Algorithm_for_Localization_of_a_TransmitterReceiver_Station_in_a_2D_Plane_Using_Analytical_Geometry 
+ * 
+ * 
+ * @param p_lag_array Pointer to an array containing the measured
+ * lags. @p p_lag_array expands to 
+ *      *p_lag_array = { lag_port, lag_starboard, lag_stern }
+ */
+std::pair<float32_t, float32_t> triliterate_pinger_position(uint32_t* p_lag_array);
+
 } /* namespace TRILATERATION */
 
 #endif /* ACOUSTICS_TRILATERATION_H */

--- a/Include/trilateration.h
+++ b/Include/trilateration.h
@@ -116,20 +116,18 @@ uint8_t initialize_trilateration_globals(
 
 
 /**
- * @brief Initializes the matrices @p A and @p B
+ * @brief Initializes the matrix @p A to a 2x3 0-matrix
  * 
- * The function sets the port hydrophone as it's initial anchor. The other
- * datapoints are therefore calculated based on the position/distance from
- * the port hydrophone
- * 
- * @retval Returns 1 if the A-matrix is invertible
- * Returns 0 if A not invertible 
- * 
- * @param A Matrix containing positions and distance between the hydrophones
+ * @retval Returns a 2x3 matrix with all entries set to 0
  */
-uint8_t initialize_trilateration_matrices(
-            Matrix_2_3_f& A,
-            Vector_2_1_f& B);
+Matrix_2_3_f initialize_A_matrix();
+
+/**
+ * @brief Initializes the vector @p B to a 2x3 0-matrix
+ * 
+ * @retval Returns a 2x1 vector with both entries set to 0
+ */
+Vector_2_1_f initialize_B_matrix();
 
 /**
  * @brief Function to calculate an estimate for the distance

--- a/Include/trilateration.h
+++ b/Include/trilateration.h
@@ -2,7 +2,8 @@
  * @file
  * 
  * @brief Basic functions to trilaterate the position of
- * the acoustic pinger
+ * the acoustic pinger. Preferable to change it with the MANYEARS-
+ * library
  */
 #ifndef ACOUSTICS_TRILATERATION_H
 #define ACOUSTICS_TRILATERATION_H

--- a/README.md
+++ b/README.md
@@ -2,22 +2,21 @@
 Repository to analyze signals from three (3) different hydrophones and estimate the positioning of a pinger in XY-coordinates.
 
 Dependencies:
-  The DSP and the analysis depends on code developed by ARM. This includes both FFT/IFFT, autocorrelation and DF1-filtering. All of the required files can be found at CMSIS at https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html
+  CMSIS-library: DSP-library developed by ARM. Found at https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html
+  MANYEARS-library: Old library specialized for trilateration. Found at https://github.com/introlab/manyears 
 
 
 Important notes:
+  The ODAS-library is an updated version of the MANYEARS-library. It can be found at https://github.com/introlab/odas, however it may not work perfectly for trilateration
 
-  Dependencies are NOT included in this repository! These must be downloaded by oneself. This is to prevent the github-page exceeding almost one million lines of code.
-
-  The code is compiled on STM32CubeIDE, however the IDE often has problems reading/understanding the types int/uint8_t/uint16_t/float32_t and so forth. No solution has been discovered as of 11.12.2020.
-  
+  The code is compiled on STM32CubeIDE, and the MAKEFILE may not be up to date. Mainly kept for the future, in case the system is compiled and run on another platform
 
 # Source files
 The source files for 2020/2021, can be found in the folder "Source" with the header files under Include. Older files are not considered relevant, and is therefore not in this repository.
 
 
 Files with a short description:
-  DSP: originally intended to hold the functions for the DSP (digital signal processing), however holds the DSP-constants at the moment. The only file that includes files from ARM
+  DSP_CONSTANTS: originally intended to hold the functions for the DSP (digital signal processing), however holds the DSP-constants at the moment. The only file that includes files from ARM
 
   TRILITERATION: Mantains the functions to calculate an estimate for heading and distance to the sound-source.
 
@@ -27,16 +26,13 @@ Files with a short description:
 
 # Resource files
 Resource files are found in the folder "Resource". 
-The folder includes the CMSIS-library, driver for STM32 and some test-scripts in MATLAB.
-
+The folder includes the CMSIS- and MANYEARS-library, driver for STM32 and a test-script in MATLAB.
 
 
 # Future improvements/development
 
 List of improvements:
-  1. Read the data from the ADC from each channel
-  2. Check the correctness of the code. Specialized tests should be written to accomodate this requirement.
-  3. Find a way to calculate the sound-intensity to estimate the distance from the sound-source
-  4. Check the RAM-usage to prevent any memory-leaks. This should be done using Valgrind or any other program
+  1. Check the correctness of the code. Specialized tests should be written to accomodate this requirement.
+  2. Check the RAM-usage to prevent any memory-leaks. This should be done using Valgrind or any other program
    
 

--- a/Resource/MATLAB/code_trilatiration.m
+++ b/Resource/MATLAB/code_trilatiration.m
@@ -1,0 +1,44 @@
+% parameter values for anchor node coordinates and signal speed 
+a = 10 ; b = 20 ; c = 30 ; v = 300 ;  
+
+% TDOA of Signals at Blind Node 
+del_t_1 = 0.05 ; % input example                 
+del_t_2 = 0.03 ; % input example 
+del_t_3 = 0.02 ; % input example   
+
+J_1 = (v.*del_t_1)./2 ; 
+J_2 = (v.*del_t_2)./2 ; 
+J_3 = (v.*del_t_3)./2 ;   
+
+x = linspace(-10, 20, 10000) ;   
+
+% Hyperbolas with side AB as transverse axis 
+y_1 = sqrt(((a+b)./2)^2 - (J_1).^2).*sqrt(((x - (b-a)./2)./(J_1)).^2 - 1) ; 
+y_2 = -sqrt(((a+b)./2)^2 - (J_1).^2).*sqrt(((x - (b-a)./2)./(J_1)).^2 - 1) ; 
+
+% Hyperbolas with side AC as transverse axis 
+A = 8.*b.*c.*x - 4.*c.*(b.^2 - c.^2) - 16.*c.*(J_2).^2 ; 
+B = sqrt(64.*((J_2).^2).*(b.^2 + c.^2 - 4.*(J_2).^2).*(4.*x.^2 - 4.*b.*x + b.^2 + c.^2 - 4.*(J_2).^2)) ; 
+C = 8.*(c.^2 - 4.*(J_2).^2) ; y_3 = (A+B)./C ; y_4 = (A-B)./C ;   
+
+% Hyperbolas with side CB as axis 
+E = -8.*a.*c.*x - 4.*c.*(a.^2 - c.^2) - 16.*c.*(J_3).^2 ; 
+F = sqrt(64.*((J_3).^2).*(a.^2 + c.^2 - 4.*(J_3).^2).*(4.*x.^2 + 4.*a.*x + a.^2 + c.^2 - 4.*(J_3).^2)) ; 
+G = 8.*(c.^2 - 4.*(J_3).^2) ;  
+
+y_5 = (E+F)./G ; 
+y_6 = (E-F)./G ;   
+
+hold on 
+plot(x,y_1,'r',x,y_2,'r') 
+plot(x,y_3,'g',x,y_4,'g') 
+plot(x,y_5,'b',x,y_6,'b') 
+plot(x,0,'k',x,3.*x+30,'k',x,-(1.5).*x+30,'k')  
+axis square 
+axis([-10 20 0 30]) 
+text(-9,0.5,'A(-10,0)') 
+text(2,29,'C(0,30)') 
+text(17,0.5,'B(20,0)') 
+text(15.75,12.5,'P_1 (x,y)') 
+text(-4.7,11.88,'P_2 (x,y)') 
+hold off

--- a/Source/hydrophones.cpp
+++ b/Source/hydrophones.cpp
@@ -5,19 +5,13 @@ HYDROPHONES::Hydrophones::Hydrophones(TRILATERATION::Pos pos) :
 {
     /* Initial memory allocation */
     p_data = (float32_t*) malloc(sizeof(float32_t) * DSP_CONSTANTS::IN_BUFFER_LENGTH);
-    p_mag_data = (float32_t*) malloc(sizeof(float32_t) * DSP_CONSTANTS::IN_BUFFER_LENGTH);
     p_autocorr_data = (float32_t*) malloc(sizeof(float32_t) * (DSP_CONSTANTS::IN_BUFFER_LENGTH * 2 - 1));
-    p_max_val = (float32_t*) malloc(sizeof(float32_t));
-    p_idx = (uint32_t*) malloc(sizeof(uint32_t));
 }
 
 HYDROPHONES::Hydrophones::~Hydrophones()
 {
     /* Deleting the allocated memory */
     free(p_data);
-    free(p_mag_data);
-    free(p_max_val);
-    free(p_idx);
     free(p_autocorr_data);
 }
 
@@ -29,15 +23,6 @@ void HYDROPHONES::Hydrophones::analyze_data(float32_t *p_raw_data)
      */ 
     arm_biquad_cascade_df1_f32(&DSP_CONSTANTS::IIR_FILTER,
             p_raw_data, p_data, DSP_CONSTANTS::IIR_SIZE);
-
-    /* Takes the complex FFT with length 4096 */
-    arm_cfft_f32(&arm_cfft_sR_f32_len4096, p_data, 0, 1);
-
-    /* Finds the complex magnitude output */
-    arm_cmplx_mag_f32(p_data, p_mag_data, DSP_CONSTANTS::FFT_SIZE);
-
-    /* Calculates the index and value for the maximum value */
-    arm_max_f32(p_mag_data, DSP_CONSTANTS::FFT_SIZE, p_max_val, p_idx);
 
     /* Taking the autocorrelation of the filtered data */
     arm_correlate_f32(p_data, DSP_CONSTANTS::FFT_SIZE, p_data, 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -132,17 +132,24 @@ int main(void)
     HYDROPHONES::Hydrophones hyd_starboard(HYDROPHONES::pos_hyd_starboard);
     HYDROPHONES::Hydrophones hyd_stern(HYDROPHONES::pos_hyd_stern);
 
+    /* Initialize the matrices used for trilatiration */
+    Matrix_2_3_f A_matrix = TRILATERATION::initialize_A_matrix();
+    Vector_2_1_f B_matrix = TRILATERATION::initialize_B_vector();
+
     /* Lag from each hydrophone */
     uint32_t lag_hyd_port, lag_hyd_starboard, lag_hyd_stern;
 
     /* Intensity measured for each hydrophone */
-    float32_t intensity_port, intensity_starboard, intensity_stern;
+    //float32_t intensity_port, intensity_starboard, intensity_stern;
 
     /* Range-estimate to the acoustic pinger */
-    float32_t distance_estimate;
+    //float32_t distance_estimate;
 
     /* Angle-estimate to the acoustic pinger */
-    float32_t angle_estimate;
+    //float32_t angle_estimate;
+
+    /* Estimated position of the acoustic pinger */
+    float32_t x_pos_es, y_pos_es;
 
     /* Initializing time-measurement */
     time_t time_initial_startup = time(NULL);
@@ -154,7 +161,7 @@ int main(void)
 
     /* Variables used to indicate error(s) with the signal */
     uint8_t bool_time_error = 0;
-    uint8_t bool_intensity_error = 0;
+    //uint8_t bool_intensity_error = 0;
 
     /* USER CODE END 2 */
 
@@ -227,10 +234,10 @@ int main(void)
         lag_hyd_stern = hyd_stern.get_lag();
         uint32_t lag_array[NUM_HYDROPHONES] = { lag_hyd_port, lag_hyd_starboard, lag_hyd_stern };
 
-        intensity_port = hyd_port.get_intensity();
-        intensity_starboard = hyd_starboard.get_intensity();
-        intensity_stern = hyd_stern.get_intensity();
-        float32_t intensity_array[NUM_HYDROPHONES] = { intensity_port, intensity_starboard, intensity_stern };
+        // intensity_port = hyd_port.get_intensity();
+        // intensity_starboard = hyd_starboard.get_intensity();
+        // intensity_stern = hyd_stern.get_intensity();
+        // float32_t intensity_array[NUM_HYDROPHONES] = { intensity_port, intensity_starboard, intensity_stern };
 
         /**
          * Checking is the measurements are valid. The measurements 
@@ -239,11 +246,11 @@ int main(void)
          * 
          * Take new samples if the data is invalid
          */
-        if(!TRILATERATION::check_valid_signals(lag_array, intensity_array,
-              &bool_time_error, &bool_intensity_error)){
-          check_signal_error(&bool_time_error, &bool_intensity_error);
-          continue;
-        }
+        // if(!TRILATERATION::check_valid_signals(lag_array, intensity_array,
+        //       &bool_time_error, &bool_intensity_error)){
+        //   check_signal_error(&bool_time_error, &bool_intensity_error);
+        //   continue;
+        // }
 
         /** 
          * Calculate estimated position of the acoustic pinger in 
@@ -254,11 +261,18 @@ int main(void)
          * The second function returns an estimate of the distance and
          * the angle to the target  
          */
-        std::pair<float32_t, float32_t> position_es = 
-            TRILATERATION::estimate_pinger_position(lag_array, intensity_array);
+        // std::pair<float32_t, float32_t> position_es = 
+        //     TRILATERATION::estimate_pinger_position(lag_array, intensity_array);
 
-        TRILATERATION::calculate_distance_and_angle(position_es, 
-              &distance_estimate, &angle_estimate);
+        // TRILATERATION::calculate_distance_and_angle(position_es, 
+        //       &distance_estimate, &angle_estimate);
+
+        /**
+         * Triliterate the position of the acoustic pinger
+         * 
+         * The coordinates are given as a reference to the center of the AUV
+         */
+        TRILATERATION::trilaterate_pinger_position(A, B, lag_array, x_pos_es, y_pos_es);
 
         /**
          * TODO@TODO

--- a/Source/trilateration.cpp
+++ b/Source/trilateration.cpp
@@ -40,7 +40,7 @@ uint8_t TRILATERATION::initialize_trilateration_globals(
                 TRILATERATION::calculate_pos_distance(pos_hyd_starboard, pos_hyd_stern);
         TRILATERATION::max_hydrophone_distance = 
                 std::max(dist_port_starboard, std::max(dist_starboard_stern, dist_port_stern));
-        TRILATERATION::max_time_diff = (1 + TRILATERATION::time_diff_epsilon) *
+        TRILATERATION::max_time_diff = (1 + MARGIN_TIME_EPSILON) *
                 (TRILATERATION::max_hydrophone_distance / TRILATERATION::sound_speed);
         return (TRILATERATION::max_hydrophone_distance != -1 && 
                 TRILATERATION::max_time_diff != 1);
@@ -207,7 +207,7 @@ uint8_t TRILATERATION::valid_time_check(const uint32_t& time_lhs, const uint32_t
 
 uint8_t TRILATERATION::valid_intensity_check(const float32_t& intensity_lhs, 
         const float32_t& intensity_rhs){
-    return std::abs(intensity_lhs - intensity_rhs) > TRILATERATION::max_intensity_diff;
+        return std::abs(intensity_lhs - intensity_rhs) > MARGIN_INTENSITY;
                 
 }
 
@@ -266,116 +266,31 @@ void TRILATERATION::transform_data(float32_t* p_data);
 /**
  * Functions for trilateration based on TDOA 
  */
-std::pair<float32_t, float32_t> TRILATERATION::triliterate_pinger_position(uint32_t* p_lag_array){
-        /**
-         * Matlab code used for reference
-         */
+void TRILATERATION::trilaterate_pinger_position(
+        const Matrix4f& A,
+        const Vector4f B,
+        uint32_t* p_lag_array,
+        float32_t& x_estimate,
+        float32_t& y_estimate){
 
-        /*
-        % parameter values for anchor node coordinates and signal speed
-        a = 10 ;
-        b = 20 ;
-        c = 30 ;
-        v = 300 ;
+        Matrix4f A_T, A_copy;
+        A_T = A.transpose();
+        A_copy = A;
 
-        % TDOA of Signals at Blind Node
-        del_t_1 = 0.05 ; % input example
-        del_t_2 = 0.03 ; % input example
-        del_t_3 = 0.02 ; % input example
-        J_1 = (v.*del_t_1)./2 ;
-        J_2 = (v.*del_t_2)./2 ;
-        J_3 = (v.*del_t_3)./2 ;
-        x = linspace(-10, 20, 10000) ;
-        % Hyperbolas with side AB as transverse axis
-        y_1 = sqrt(((a+b)./2)^2 - (J_1).^2).*sqrt(((x - (b-a)./2)./(J_1)).^2 - 1) ;
-        y_2 = -sqrt(((a+b)./2)^2 - (J_1).^2).*sqrt(((x - (b-a)./2)./(J_1)).^2 - 1) ;
-        % Hyperbolas with side AC as transverse axis
-        A = 8.*b.*c.*x - 4.*c.*(b.^2 - c.^2) - 16.*c.*(J_2).^2 ;
-        B = sqrt(64.*((J_2).^2).*(b.^2 + c.^2 - 4.*(J_2).^2).*(4.*x.^2 - 4.*b.*x +
-        b.^2 + c.^2 - 4.*(J_2).^2)) ;
-        C = 8.*(c.^2 - 4.*(J_2).^2) ;
-        y_3 = (A+B)./C ;
-        y_4 = (A-B)./C ;
-        % Hyperbolas with side CB as axis
-        E = -8.*a.*c.*x - 4.*c.*(a.^2 - c.^2) - 16.*c.*(J_3).^2 ;
-        F = sqrt(64.*((J_3).^2).*(a.^2 + c.^2 - 4.*(J_3).^2).*(4.*x.^2 + 4.*a.*x +
-        a.^2 + c.^2 - 4.*(J_3).^2)) ;
-        G = 8.*(c.^2 - 4.*(J_3).^2) ;
-        y_5 = (E+F)./G ;
-        y_6 = (E-F)./G ;
-        hold on
-        plot(x,y_1,'r',x,y_2,'r')
-        plot(x,y_3,'g',x,y_4,'g')
-        plot(x,y_5,'b',x,y_6,'b')
-        plot(x,0,'k',x,3.*x+30,'k',x,-(1.5).*x+30,'k')
-        axis square
-        axis([-10 20 0 30])
-        text(-9,0.5,'A(-10,0)')
-        text(2,29,'C(0,30)')
-        text(17,0.5,'B(20,0)')
-        text(15.75,12.5,'P_1 (x,y)')
-        text(-4.7,11.88,'P_2 (x,y)')
-        hold off
-        */
+        /* Calculating the solution-vector */
+        Vector4f state_vec = (A_T * A_copy).inverse() * A_T * B;
 
-        /**
-         * Recovering the values from the arrays
-         */
-        uint32_t lag_port, lag_starboard, lag_stern;
-
-        lag_port = p_lag_array[0];
-        lag_starboard = p_lag_array[1];
-        lag_stern = p_lag_array[2];
-
-
-        /**
-         * Calculating the TDOA (time difference on arrival)
-         */
-        uint32_t diff_lag_port_starboard = abs(lag_port - lag_starboard);
-        uint32_t diff_lag_port_stern = abs(lag_port - lag_stern);
-        uint32_t diff_lag_starboard_stern = abs(lag_starboard - lag_stern);
-
-        /**
-         * Calculating the estimated distance from the midpoint of each hydrophone to the 
-         * acoustic pinger
-         */
-        float32_t r_port_starboard, r_port_stern, r_starboard_stern;
-        r_port_starboard = (float32_t)(TRILATERATION::sound_speed * diff_lag_port_starboard) / 2.0f;
-        r_port_stern = (float32_t)(TRILATERATION::sound_speed * diff_lag_port_stern) / 2.0f;
-        r_starboard_stern = (float32_t)(TRILATERATION::sound_speed * diff_lag_starboard_stern) / 2.0f;
-
-        /**
-         * Moving the reference-frame, such that the point (x,y) calculated is relative to 
-         * the center of the AUV
-         * 
-         * Using positions A, B and C to symbolize the hydrophones positions. See the research-
-         * paper for further details. These values are used (instead of the predetermined hydrophones'
-         * positions) since the reference-frame must be moved
-         *      A: Port hydrophone
-         *      B: Starboard hydrophone
-         *      C: Stern hydrophone
-         * 
-         * Therefore the values a, b and c completely determines the position of the hydrophones. It
-         * is assumed that z = 0:
-         *      A := (-a, 0, 0)
-         *      B := (b, 0, 0)
-         *      C := (0, c, 0)
-         */
-        float32_t a, b, c;
-        a = PORT_HYD_X;
-        b = STARBOARD_HYD_X;
-
-        if(STERN_HYD_X){
-                a += STERN_HYD_X;
-                b -= STERN_HYD_X;
-        }
-
-        c = STERN_HYD_Y;
-
-        /**
-         * Pherhaps necessary using a rotational-matrix here
-         */
+        x_estimate = state_vec.coeff(0);
+        y_estimate = state_vec.coeff(1);
+}
 
 
 
+
+float32_t TRILATERATION::calculate_plane_distance(
+            const float32_t& x1,
+            const float32_t& y1,
+            const float32_t& x2,
+            const float32_t& y2){
+        return std::sqrt(std::pow(x1 - x2, 2) + std::pow(y1 - y2));
 }

--- a/Source/trilateration.cpp
+++ b/Source/trilateration.cpp
@@ -47,6 +47,21 @@ uint8_t TRILATERATION::initialize_trilateration_globals(
 }
 
 
+Matrix_2_3_f initialize_A_matrix(){
+        Matrix_2_3_f A << 0, 0, 0,
+                          0, 0, 0;
+        return A;
+}
+
+
+Vector_2_1_f initialize_B_matrix(){
+        Vector_2_1_f B << 0,
+                          0;
+        return B;
+}
+
+
+
 /**
  * Functions for trilateration, estimation and calculation for
  * the position and angles


### PR DESCRIPTION
The code used for trilateration has been modified to another method of trilaterating the position of the acoustic pinger. The new method is (hopefully) more reliable in both estimating the position and more tolerable towards noise and other inaccuracies. Should improve #19 and solve #22 

Some code in the files have been commented out or moved. This lead up to the next merge/pr which should focus on cleaning the entire workspace 