### PR TITLE
Signal Generation Upgrades

### DIFF
--- a/Python/conftest.py
+++ b/Python/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runplot",
+        action="store_true",
+        default=False,
+        help="Run tests with plots",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "plot: mark test containing plotting")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runplot"):
+        # --runplot given in cli: do not skip test with plots
+        return
+    skip_plots = pytest.mark.skip(reason="need --runplot option to run")
+    for item in items:
+        if "plot" in item.keywords:
+            item.add_marker(skip_plots)

--- a/Python/signal_generation/noise.py
+++ b/Python/signal_generation/noise.py
@@ -1,0 +1,55 @@
+"""Provides functions to generate noise to introduce to generated signals.
+
+The noise generated here will be of type float and should be introduced before
+converting the signals to integers.
+"""
+
+import numpy as np
+
+
+def generate_gaussian_noise(
+    length: int,
+    variance: float,
+    maximum_allowed_value: float = None,
+) -> np.array:
+    """Generates white (zero-mean) gaussian noise with given length.
+
+    Args:
+        length: The length of the output array in samples.
+        variance: The variance of the gaussian distribution.
+        maximum_allowed: If a maximum allowed value is supplied, then the values
+            are clipped at [-max_value, max_value]. Beware that this messes with
+            the noise being a gaussian distribution.
+
+    Return:
+        An array of white gaussian noise with given length that is optionally clipped
+        to output range [-maximum_allowed_value, maximum_allowed_value] of type float.
+    """
+
+    noise = np.random.normal(0, np.sqrt(variance), length)
+    if maximum_allowed_value is not None:
+        noise[np.where(noise > maximum_allowed_value)] = maximum_allowed_value
+        noise[np.where(noise < -maximum_allowed_value)] = -maximum_allowed_value
+
+    return noise
+
+
+def generate_uniform_noise(
+    length: int,
+    maximum_allowed_value: float = 1.0,
+) -> np.array:
+    """Generates white uniform noise with given length.
+
+    Args:
+        length: The length of the output array in samples.
+
+    Return:
+        An array of white uniform noise with given length with output range from
+        [-maximum_allowed_value, maximum_allowed_value].
+    """
+
+    return np.random.uniform(
+        low=-maximum_allowed_value,
+        high=maximum_allowed_value,
+        size=length,
+    )

--- a/Python/signal_generation/positioning.py
+++ b/Python/signal_generation/positioning.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Iterable
 
 import numpy as np
 
@@ -65,3 +66,28 @@ def find_maximum_distance(
     )
 
     return np.max(distances)
+
+
+def calculate_distances(
+    source_positions: np.array,
+    receiver_positions: np.array,
+    sound_speed: float = 1500,  # [m/s]
+) -> Iterable[float]:
+    """Calculate the distances from the sources to the hydrophones.
+
+    Args:
+        source_positions: Provide the positions for the source.
+        receiver_positions: Provide the positions of the receivers
+
+    Returns:
+        A 2D numpy.array containing the distances in meters [m].
+        Where the first index is used for sources and the second for receivers,
+        so distances[0][2] would give the distance from the zeroth source
+        to the 2nd receiver.
+    """
+    distances = np.empty((len(source_positions), len(receiver_positions)))
+
+    for index, source_position in enumerate(source_positions):
+        distances[index, :] = abs(receiver_positions - source_position)
+
+    return distances

--- a/Python/signal_generation/test/test_noise.py
+++ b/Python/signal_generation/test/test_noise.py
@@ -1,0 +1,70 @@
+import signal_generation.noise as noise
+
+
+class TestGaussianNoise:
+    @staticmethod
+    def test_when_generate_gaussian_noise_then_no_error():
+        gaussian = noise.generate_gaussian_noise(
+            length=100,
+            variance=0.5,
+            maximum_allowed_value=None,
+        )
+
+    @staticmethod
+    def test_given_length_then_length_correct():
+        reference_length = 100
+
+        gaussian = noise.generate_gaussian_noise(
+            length=reference_length,
+            variance=0.5,
+            maximum_allowed_value=None,
+        )
+
+        result_length = len(gaussian)
+
+        assert result_length == reference_length
+
+    @staticmethod
+    def test_given_maximum_then_no_values_exceed_maximum():
+        maximum = 0.3
+
+        gaussian = noise.generate_gaussian_noise(
+            length=1000,
+            variance=0.7,
+            maximum_allowed_value=maximum,
+        )
+
+        assert all(abs(gaussian) <= maximum)
+
+
+class TestUniformNoise:
+    @staticmethod
+    def test_when_generate_uniform_noise_then_no_error():
+        uniform = noise.generate_uniform_noise(
+            length=100,
+            maximum_allowed_value=1.0,
+        )
+
+    @staticmethod
+    def test_given_length_then_length_correct():
+        reference_length = 100
+
+        uniform = noise.generate_uniform_noise(
+            length=reference_length,
+            maximum_allowed_value=1.0,
+        )
+
+        result_length = len(uniform)
+
+        assert result_length == reference_length
+
+    @staticmethod
+    def test_given_maximum_then_no_values_exceed_maximum():
+        maximum = 0.3
+
+        uniform = noise.generate_uniform_noise(
+            length=1000,
+            maximum_allowed_value=maximum,
+        )
+
+        assert all(abs(uniform) <= maximum)

--- a/Python/signal_generation/test/test_positioning.py
+++ b/Python/signal_generation/test/test_positioning.py
@@ -1,28 +1,30 @@
 import numpy as np
 
-import signal_generation.positioning as pos
+import pytest
+
+import signal_generation.positioning as sg_pos
 
 
 class TestPosition:
     @staticmethod
     def test_when_initialized_then_success():
-        position = pos.Position()
+        position = sg_pos.Position()
 
     @staticmethod
     def test_given_close_to_equal_position_when_test_equality_then_equal():
-        position_one = pos.Position()
-        position_two = pos.Position(
-            x=1 * 10 ** (-1) * pos.Position.tol,
-            y=(-1) * 10 ** (-10) * pos.Position.tol,
-            z=5 * 10 ** (-10) * pos.Position.tol,
+        position_one = sg_pos.Position()
+        position_two = sg_pos.Position(
+            x=1 * 10 ** (-1) * sg_pos.Position.tol,
+            y=(-1) * 10 ** (-10) * sg_pos.Position.tol,
+            z=5 * 10 ** (-10) * sg_pos.Position.tol,
         )
 
         assert position_one == position_two
 
     @staticmethod
     def test_given_unequal_positions_when_test_equality_then_not_equal():
-        position_one = pos.Position()
-        position_two = pos.Position(
+        position_one = sg_pos.Position()
+        position_two = sg_pos.Position(
             x=-10,
             y=-20,
             z=-30,
@@ -42,25 +44,89 @@ class TestPosition:
         y_0 = 14
         z_0 = -22
 
-        position_one = pos.Position(x=x_0, y=y_0, z=z_0)
-        position_two = pos.Position(x=x_0 + ref_x, y=y_0 + ref_y, z=z_0 + ref_z)
+        position_one = sg_pos.Position(x=x_0, y=y_0, z=z_0)
+        position_two = sg_pos.Position(x=x_0 + ref_x, y=y_0 + ref_y, z=z_0 + ref_z)
 
         res_distance = abs(position_one - position_two)
 
-        assert (res_distance - ref_distance) < pos.Position.tol
+        assert (res_distance - ref_distance) < sg_pos.Position.tol
 
 
 def test_maximum_distance():
     positions = np.array(
         [
-            pos.Position(),
-            pos.Position(x=10.0),
-            pos.Position(x=2.0),
-            pos.Position(x=30.0),
+            sg_pos.Position(),
+            sg_pos.Position(x=10.0),
+            sg_pos.Position(x=2.0),
+            sg_pos.Position(x=30.0),
         ]
     )
     ref_distance = 30.0
 
-    res_distance = pos.find_maximum_distance(positions=positions)
+    res_distance = sg_pos.find_maximum_distance(positions=positions)
 
     assert res_distance == ref_distance
+
+
+class TestCalculateDistances:
+    @staticmethod
+    def test_given_single_source_and_receiver_then_shape_as_expected():
+        source_positions = np.array([sg_pos.Position()])
+        receiver_positions = np.array([sg_pos.Position()])
+
+        ref_shape = (len(source_positions), len(receiver_positions))
+
+        distances = sg_pos.calculate_distances(
+            source_positions=source_positions,
+            receiver_positions=receiver_positions,
+        )
+
+        res_shape = np.shape(distances)
+
+        assert res_shape == ref_shape
+
+    @staticmethod
+    def test_given_multiple_sources_and_receivers_then_shape_as_expected():
+        source_positions = np.array(
+            [sg_pos.Position(), sg_pos.Position()],
+        )
+        receiver_positions = np.array(
+            [sg_pos.Position(), sg_pos.Position(), sg_pos.Position()],
+        )
+
+        ref_shape = (len(source_positions), len(receiver_positions))
+
+        distances = sg_pos.calculate_distances(
+            source_positions=source_positions,
+            receiver_positions=receiver_positions,
+        )
+
+        res_shape = np.shape(distances)
+
+        assert res_shape == ref_shape
+
+    @staticmethod
+    def test_given_source_and_receiver_position_then_distance_within_tolerance():
+        source_positions = np.array([sg_pos.Position(x=0, y=0, z=1)])
+        receiver_positions = np.array(
+            [
+                sg_pos.Position(x=1, y=0, z=1),
+                sg_pos.Position(x=0, y=1, z=0),
+            ]
+        )
+
+        ref_distances = np.array(
+            [
+                [
+                    np.sqrt(1),
+                    np.sqrt(1 + 1),
+                ]
+            ]
+        )
+
+        res_distances = sg_pos.calculate_distances(
+            source_positions=source_positions,
+            receiver_positions=receiver_positions,
+        )
+
+        assert (abs(res_distances - ref_distances) < 1 * 10 ** (-6)).all()

--- a/Python/signal_generation/test/test_receiver.py
+++ b/Python/signal_generation/test/test_receiver.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import signal_generation.conversion as conv
 import signal_generation.receiver as rec
 import signal_generation.positioning as pos
 import signal_generation.source as src
@@ -79,3 +80,42 @@ class TestHydrophoneArray:
         )
 
         assert np.shape(result) == (4, int(output_length * pinger.sampling_frequency))
+
+    @staticmethod
+    def test_given_geometric_spreading_then_max_amplitude_far_below_input_amplitude():
+        amplitude = 1.0
+
+        positions = [
+            pos.Position(),
+        ]
+
+        hydro_array = rec.HydrophoneArray(
+            positions=positions,
+        )
+
+        pinger = src.Pinger(
+            frequency=10.0,  # [kHz]
+        )
+        pinger_position = pos.Position(
+            x=10.0,
+            y=11.2,
+            z=10.2,
+        )
+
+        output_length = 100.0
+
+        result = hydro_array.generate_signals(
+            amplitude=amplitude,
+            output_length=output_length,
+            source=pinger,
+            source_position=pinger_position,
+            output_data_type=np.int32,
+            sound_speed=1500.0,
+            geometric_spreading=True,
+        )
+
+        integer_amplitude = conv.convert_to_integer_type(
+            input_signal=np.array([amplitude]),
+            resulting_type=np.int32,
+        )
+        assert np.max(abs(result)) <= np.max(integer_amplitude / abs(pinger_position))

--- a/Python/signal_generation/test/test_signal_generation.py
+++ b/Python/signal_generation/test/test_signal_generation.py
@@ -1,0 +1,183 @@
+""" Provides tests to demonstrate usage of modules inside package
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import signal_generation.conversion as sg_conv
+import signal_generation.noise as sg_noise
+import signal_generation.positioning as sg_pos
+import signal_generation.receiver as sg_rec
+import signal_generation.source as sg_src
+
+
+@pytest.mark.plot
+def test_given_multiple_sources_then_multiple_frequencies():
+    positions = np.array(
+        [
+            sg_pos.Position(),
+        ]
+    )
+
+    hydro_array = sg_rec.HydrophoneArray(
+        positions=positions,
+    )
+
+    pinger_position_one = sg_pos.Position(
+        x=3.0,
+        y=-2.2,
+        z=1.2,
+    )
+    pinger_position_two = sg_pos.Position(
+        x=3.0,
+        y=-2.2,
+        z=4.2,
+    )
+    pinger = [
+        sg_src.Pinger(
+            frequency=10.0,  # [kHz]
+            period=30.0,
+            pulse_length=15.0,
+            use_window=True,
+            position=pinger_position_one,
+        ),
+        sg_src.Pinger(
+            frequency=20.0,  # [kHz]
+            period=30.0,
+            pulse_length=15.0,
+            use_window=True,
+            position=pinger_position_two,
+        ),
+    ]
+
+    result = sg_rec.generate_signals(
+        sources=pinger,
+        receivers=hydro_array,
+        output_length=2000,
+        sound_speed=1500.0,
+    )
+
+    fig, axs = plt.subplots(2, 1)
+    fig.tight_layout()
+    axs[0].plot(result[0])
+    axs[0].set_xlabel("n")
+    axs[0].set_xlim([250, 500])
+    axs[1].plot(abs(np.fft.fft(result[0])))
+    axs[1].set_xlabel("frequency bins")
+
+    plt.show()
+
+
+@pytest.mark.plot
+def test_given_single_source_when_geometrical_spreading_then_amplitude_decay():
+    positions = np.array(
+        [
+            sg_pos.Position(),
+            sg_pos.Position(x=3.0, y=0.0, z=0.0),
+            sg_pos.Position(x=6.0, y=0.0, z=0.0),
+            sg_pos.Position(x=9.0, y=0.0, z=0.0),
+            sg_pos.Position(x=12.0, y=0.0, z=0.0),
+        ]
+    )
+
+    hydro_array = sg_rec.HydrophoneArray(
+        positions=positions,
+    )
+
+    pinger = [
+        sg_src.Pinger(
+            frequency=10.0,  # [kHz]
+            period=30.0,
+            pulse_length=15.0,
+            use_window=True,
+            position=sg_pos.Position(),
+        ),
+    ]
+
+    result = sg_rec.generate_signals(
+        sources=pinger,
+        receivers=hydro_array,
+        output_length=2000,
+        sound_speed=1500.0,
+        geometric_spreading=True,
+    )
+
+    plt.plot(result[0], label=f"{hydro_array.positions[0]}")
+    plt.plot(result[1], label=f"{hydro_array.positions[1]}")
+    plt.plot(result[2], label=f"{hydro_array.positions[2]}")
+    plt.plot(result[3], label=f"{hydro_array.positions[3]}")
+    plt.plot(result[4], label=f"{hydro_array.positions[4]}")
+    plt.xlabel("n")
+    plt.legend()
+
+    plt.show()
+
+
+@pytest.mark.plot
+def test_given_multiple_receivers_and_noise_when_conversion_then_difference_in_arrivals():
+    positions = np.array(
+        [
+            sg_pos.Position(),
+            sg_pos.Position(x=2.0, y=0.0, z=0.0),
+            sg_pos.Position(x=1.5, y=0.0, z=0.5),
+            sg_pos.Position(x=0.0, y=0.6, z=0.0),
+        ]
+    )
+
+    hydro_array = sg_rec.HydrophoneArray(
+        positions=positions,
+    )
+
+    pinger = [
+        sg_src.Pinger(
+            frequency=10.0,  # [kHz]
+            period=30.0,
+            pulse_length=15.0,
+            use_window=True,
+            position=sg_pos.Position(x=10.0, y=5.0, z=8.0),
+        ),
+    ]
+
+    output_length = 2000
+
+    result = 0.7 * sg_rec.generate_signals(
+        sources=pinger,
+        receivers=hydro_array,
+        output_length=output_length,
+        sound_speed=1500.0,
+    )
+
+    variance = 0.01
+    result[0] += sg_noise.generate_gaussian_noise(
+        length=output_length,
+        variance=variance,
+    )
+    result[1] += sg_noise.generate_gaussian_noise(
+        length=output_length,
+        variance=variance,
+    )
+    result[2] += sg_noise.generate_gaussian_noise(
+        length=output_length,
+        variance=variance,
+    )
+    result[3] += sg_noise.generate_gaussian_noise(
+        length=output_length,
+        variance=variance,
+    )
+
+    result = sg_conv.convert_to_integer_type(
+        resulting_type=np.uint16,
+        input_signal=result,
+    )
+
+    fig, axs = plt.subplots(5, 1)
+    fig.tight_layout()
+    for index, res in enumerate(result):
+        axs[index].plot(res)
+        axs[index].set_xlabel("n")
+        axs[index].set_xlim([600, 1200])
+        axs[4].plot(res, "--", label=f"{hydro_array.positions[index]}")
+    axs[4].set_xlim([600, 1200])
+    axs[4].legend()
+
+    plt.show()

--- a/Python/signal_generation/test/test_source.py
+++ b/Python/signal_generation/test/test_source.py
@@ -1,6 +1,37 @@
 import pytest
+import scipy.signal.windows
 
 import signal_generation.source as source
+
+
+class TestWindowGeneration:
+    @staticmethod
+    def test_given_odd_pulse_length_100_percent_window_then_equal_to_hann():
+        reference = scipy.signal.windows.hann(
+            M=101,
+            sym=True,
+        )
+
+        result = source.generate_pulse_window(
+            pulse_length=101,
+            start_end_percentage=100,
+        )
+
+        assert (result == reference).all()
+
+    @staticmethod
+    def test_given_10_percent_window_then_roughly_90_percent_ones():
+        percentage = 10
+        reference_percentage = 100.0 - percentage
+
+        window = source.generate_pulse_window(
+            pulse_length=10000,
+            start_end_percentage=percentage,
+        )
+
+        result_percentage = sum(window == 1.0) / len(window) * 100
+
+        assert abs(result_percentage - reference_percentage) < 2
 
 
 class TestPinger:

--- a/Python/signal_generation/test/test_source.py
+++ b/Python/signal_generation/test/test_source.py
@@ -87,23 +87,21 @@ class TestPinger:
 
     @staticmethod
     def test_given_amplitude_when_generate_signal_then_max_smaller_or_equal_to_amplitude():
+        ref_amplitude = 0.3
         s = source.Pinger(
+            amplitude=ref_amplitude,
             frequency=10,
             pulse_length=100,
             period=1000,
         )
 
-        ref_amplitude = 0.3
         out = s.generate_signal(
-            amplitude=ref_amplitude,
             length=2000,
         )
 
-        res_max = max(out)
-        res_min = min(out)
+        res_max = max(abs(out))
 
         assert res_max < ref_amplitude + 1 * 10 ** (-9)
-        assert abs(res_min) < ref_amplitude + 1 * 10 ** (-9)
 
     @staticmethod
     def test_given_length_double_the_period_when_generate_signal_then_two_pulses():
@@ -111,13 +109,15 @@ class TestPinger:
         Take low frequency to only have positive values in pulse and find
         number of sections that are zero.
         """
+        period = 1000
+
         s = source.Pinger(
             frequency=0.01,
             pulse_length=10,
-            period=1000,
+            period=period,
         )
         out = s.generate_signal(
-            length=2000,
+            length=int(2 * period * s.sampling_frequency),
         )
 
         number_of_zero_sections = 0
@@ -136,22 +136,24 @@ class TestPinger:
 
     @staticmethod
     def test_given_offset_and_pulse_length_larger_than_period_when_generate_signal_then_success():
+        period = 30
         s = source.Pinger(
             frequency=10,
             pulse_length=10,
-            period=30,
+            period=period,
         )
         out = s.generate_signal(
             offset=25,
-            length=30,
+            length=int(period * s.sampling_frequency),
         )
 
     @staticmethod
     def test_given_offset_and_pulse_length_larger_than_period_when_generate_one_period_then_last_samples_not_zero():
+        period = 20
         s = source.Pinger(
             frequency=10,
             pulse_length=10,
-            period=20,
+            period=period,
         )
         out = s.generate_signal(
             offset=15,


### PR DESCRIPTION
Additional features for signal generation include:

- geometrical spreading
- placing multiple sources
- add noise

The general usage can be found in the `signal_generation/tests/test_signal_generation.py`. Because these tests include plotting they are skipped by default. Use `pytest --runplot` to run these tests.
Especially the last test should be looked at, because it includes multiple receivers, added noise, and conversion. 

I have tried messing around with correlation, but I have not gotten the expected results. So that's something to look into. There were some issues with using int vs float and possibly DC-offsets, but I have not spent much time on it yet.

The following plots are the ones generated from the tests.
- Multiple sources, where one is placed further away and you can see the superposition setting in at about 410 samples:
![signal_generation_plot_two_sources](https://user-images.githubusercontent.com/90988086/142781945-f0b4919c-d6a1-4389-a1bc-2d9967ab6323.png)
- One Source and multiple receivers with activated geometrical spreading and decreasing amplitudes:
![signal_generation_plot_geometrical_spreading](https://user-images.githubusercontent.com/90988086/142781998-b655e9dd-2e1b-42ee-a682-d967a3719982.png)
- Multiple receivers with added noise and unsigned integer conversion:
![signal_generation_plot_multi_receivers_noise_conversion](https://user-images.githubusercontent.com/90988086/142782029-9e3ec497-57c9-4c54-9a81-65d5609d4fda.png)