### PR TITLE
Add simple header generation

### DIFF
--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -4,6 +4,7 @@ click==8.0.3
 cycler==0.11.0
 fonttools==4.31.1
 iniconfig==1.1.1
+Jinja2==3.0.3
 kiwisolver==1.4.0
 matplotlib==3.5.1
 mypy-extensions==0.4.3
@@ -18,7 +19,7 @@ pyparsing==2.4.7
 pytest==6.2.5
 python-dateutil==2.8.2
 regex==2021.10.21
-scipy==1.7.1
+scipy==1.7.3
 six==1.16.0
 toml==0.10.2
 tomli==1.2.1

--- a/Python/utilities/generate_headers.py
+++ b/Python/utilities/generate_headers.py
@@ -1,0 +1,90 @@
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+from jinja2 import Environment, FileSystemLoader
+
+
+FILE_PATH = os.path.abspath(os.path.dirname(__file__)) 
+TEMPLATES_DIR = Path(FILE_PATH) / "templates"
+
+TYPE_TABLE = {
+    np.float16: "float16_t",
+    np.float32: "float32_t",
+    np.int16: "int16_t",
+    np.int32: "int32_t",
+}
+
+CRITICAL_FLOAT_TYPES = [
+    np.double,
+    np.longdouble,
+    np.float64,
+    np.float128,
+]
+
+CRITICAL_INT_TYPES = [
+    np.int,
+    np.int_,
+    np.int64,
+    np.longlong,
+]
+
+JINJA_ENV = Environment(
+    loader=FileSystemLoader(TEMPLATES_DIR),
+)
+
+TEMPLATE = JINJA_ENV.get_template("template_header.h")
+
+
+def convert_to_compatible_type(data):
+    if data.dtype in CRITICAL_FLOAT_TYPES:
+        logging.debug("BEWARE: down conversion on float type")
+        return data.astype(np.float32)
+
+    if data.dtype in CRITICAL_INT_TYPES:
+        logging.debug("BEWARE: down conversion on int type")
+        return data.astype(np.int32)
+
+    return data
+
+
+def convert_shape_to_c_dimension(data):
+    c_dimension_indicator = ""
+    for length in np.shape(data):
+        c_dimension_indicator += f"[{length}]"
+
+    return c_dimension_indicator
+
+
+def generate_header(
+    input_data: np.ndarray,
+    result_data: np.ndarray,
+    namespace: str = None,
+    output_path: Path = Path() / "temp.h",
+):
+    """Generates header file with the provided input and result data.
+
+    Can be used to generate test data for the Teensy from Numpy arrays.
+
+    Args:
+        input_data: A Numpy array containing the necessary input values.
+        result_data: A Numpy array containing the expected output values.
+    """
+    if (type(input_data) is not np.ndarray) or (type(result_data) is not np.ndarray):
+        raise TypeError("Arguments must be of type np.ndarray")
+
+    input_data = convert_to_compatible_type(input_data)
+    result_data = convert_to_compatible_type(result_data)
+
+    with open(output_path, "w") as output_file:
+        output_file.write(TEMPLATE.render(
+            namespace=namespace,
+            input_type="{data_type}_t".format(data_type=str(input_data.dtype)),
+            input_dimensions=convert_shape_to_c_dimension(input_data),
+            input_data=input_data.flatten(),
+            result_type="{data_type}_t".format(data_type=str(result_data.dtype)),
+            result_dimensions=convert_shape_to_c_dimension(result_data),
+            result_data=result_data.flatten(),
+        ))
+

--- a/Python/utilities/generate_headers.py
+++ b/Python/utilities/generate_headers.py
@@ -5,8 +5,7 @@ from pathlib import Path
 import numpy as np
 from jinja2 import Environment, FileSystemLoader
 
-
-FILE_PATH = os.path.abspath(os.path.dirname(__file__)) 
+FILE_PATH = os.path.abspath(os.path.dirname(__file__))
 TEMPLATES_DIR = Path(FILE_PATH) / "templates"
 
 TYPE_TABLE = {
@@ -78,13 +77,14 @@ def generate_header(
     result_data = convert_to_compatible_type(result_data)
 
     with open(output_path, "w") as output_file:
-        output_file.write(TEMPLATE.render(
-            namespace=namespace,
-            input_type="{data_type}_t".format(data_type=str(input_data.dtype)),
-            input_dimensions=convert_shape_to_c_dimension(input_data),
-            input_data=input_data.flatten(),
-            result_type="{data_type}_t".format(data_type=str(result_data.dtype)),
-            result_dimensions=convert_shape_to_c_dimension(result_data),
-            result_data=result_data.flatten(),
-        ))
-
+        output_file.write(
+            TEMPLATE.render(
+                namespace=namespace,
+                input_type="{data_type}_t".format(data_type=str(input_data.dtype)),
+                input_dimensions=convert_shape_to_c_dimension(input_data),
+                input_data=input_data.flatten(),
+                result_type="{data_type}_t".format(data_type=str(result_data.dtype)),
+                result_dimensions=convert_shape_to_c_dimension(result_data),
+                result_data=result_data.flatten(),
+            )
+        )

--- a/Python/utilities/templates/template_header.h
+++ b/Python/utilities/templates/template_header.h
@@ -1,0 +1,10 @@
+#include "arm_math.h"
+
+{% if namespace%}
+namespace {{ namespace }} {
+{% endif %}
+{{ input_type }} input_data{{ input_dimensions }} = { {% for value in input_data %}{{ value }},{% endfor %} };
+{{ result_type }} reference_data{{ result_dimensions }} = { {% for value in result_data %}{{ value }},{% endfor %} };
+{% if namespace%}
+}
+{% endif %}

--- a/Python/utilities/test/test_generate_header.py
+++ b/Python/utilities/test/test_generate_header.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-
 import utilities.generate_headers as utils_gh
 
 
@@ -14,7 +13,9 @@ def temp_output_file():
     yield temp_file_path
     os.remove(temp_file_path)
 
-@pytest.mark.parametrize("data_type, result_type",
+
+@pytest.mark.parametrize(
+    "data_type, result_type",
     [
         [np.single, np.float32],
         [np.double, np.float32],
@@ -24,7 +25,7 @@ def temp_output_file():
         [np.int16, np.int16],
         [np.int32, np.int32],
         [np.int64, np.int32],
-    ]
+    ],
 )
 def test_given_data_type_then_compatible_type(data_type, result_type):
     data = np.array([42, 42], dtype=data_type)
@@ -34,14 +35,17 @@ def test_given_data_type_then_compatible_type(data_type, result_type):
     assert data.dtype == result_type
 
 
-@pytest.mark.parametrize("input_data, expected_c_dimensions",
+@pytest.mark.parametrize(
+    "input_data, expected_c_dimensions",
     [
         [np.zeros((3,)), "[3]"],
-        [np.zeros((3,4)), "[3][4]"],
-        [np.zeros((3,6,3)), "[3][6][3]"],
-    ]
+        [np.zeros((3, 4)), "[3][4]"],
+        [np.zeros((3, 6, 3)), "[3][6][3]"],
+    ],
 )
-def test_given_input_data_then_c_dimensions_generated(input_data, expected_c_dimensions):
+def test_given_input_data_then_c_dimensions_generated(
+    input_data, expected_c_dimensions
+):
     generated_c_dimensions = utils_gh.convert_shape_to_c_dimension(input_data)
 
     assert generated_c_dimensions == expected_c_dimensions
@@ -52,7 +56,7 @@ def test_given_input_and_output_data_then_header_generated(temp_output_file):
     output_data = np.array([[42, 42], [21, 21]], dtype=np.float64)
 
     namespace = "uwotmate"
-    
+
     utils_gh.generate_header(
         namespace=namespace,
         input_data=input_data,
@@ -66,4 +70,3 @@ def test_given_input_and_output_data_then_header_generated(temp_output_file):
     assert f"namespace {namespace}" in data  # namespace naming used properly
     assert "float16_t input_data" in data  # input data variable correct
     assert "float32_t reference_data" in data  # output data variable correct
-

--- a/Python/utilities/test/test_generate_header.py
+++ b/Python/utilities/test/test_generate_header.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import utilities.generate_headers as utils_gh
+
+
+@pytest.fixture()
+def temp_output_file():
+    temp_file_path = Path() / "temp_header.h"
+    temp_file_path.touch()
+    yield temp_file_path
+    os.remove(temp_file_path)
+
+@pytest.mark.parametrize("data_type, result_type",
+    [
+        [np.single, np.float32],
+        [np.double, np.float32],
+        [np.float16, np.float16],
+        [np.float32, np.float32],
+        [np.float64, np.float32],
+        [np.int16, np.int16],
+        [np.int32, np.int32],
+        [np.int64, np.int32],
+    ]
+)
+def test_given_data_type_then_compatible_type(data_type, result_type):
+    data = np.array([42, 42], dtype=data_type)
+
+    data = utils_gh.convert_to_compatible_type(data)
+
+    assert data.dtype == result_type
+
+
+@pytest.mark.parametrize("input_data, expected_c_dimensions",
+    [
+        [np.zeros((3,)), "[3]"],
+        [np.zeros((3,4)), "[3][4]"],
+        [np.zeros((3,6,3)), "[3][6][3]"],
+    ]
+)
+def test_given_input_data_then_c_dimensions_generated(input_data, expected_c_dimensions):
+    generated_c_dimensions = utils_gh.convert_shape_to_c_dimension(input_data)
+
+    assert generated_c_dimensions == expected_c_dimensions
+
+
+def test_given_input_and_output_data_then_header_generated(temp_output_file):
+    input_data = np.array([10, 10], dtype=np.float16)
+    output_data = np.array([[42, 42], [21, 21]], dtype=np.float64)
+
+    namespace = "uwotmate"
+    
+    utils_gh.generate_header(
+        namespace=namespace,
+        input_data=input_data,
+        result_data=output_data,
+        output_path=temp_output_file,
+    )
+
+    with open(temp_output_file, "r") as generated_file:
+        data = generated_file.read()
+
+    assert f"namespace {namespace}" in data  # namespace naming used properly
+    assert "float16_t input_data" in data  # input data variable correct
+    assert "float32_t reference_data" in data  # output data variable correct
+


### PR DESCRIPTION
This function can be used to generate C/C++ header files containing input and expected output arrays. At the moment it only takes numpy arrays and doesn't handle well with singular values. In addition all values are placed on the same line which means the line length can be extremely large given a large numpy array.
This can be fixed by running `clang-format` on the generated file though.

Made this because I might need it for porting the pulse detection at some point.